### PR TITLE
fix go-ldap-admin自启失败的问题

### DIFF
--- a/docs/01.项目相关/11.安装入门/06.centos安装 Go-Ldap-Admin.md
+++ b/docs/01.项目相关/11.安装入门/06.centos安装 Go-Ldap-Admin.md
@@ -521,6 +521,10 @@ Description=Go Ldap Admin Service
 [Service]
 WorkingDirectory=/data/www/go-ldap-admin/
 ExecStart=/data/www/go-ldap-admin/go-ldap-admin
+Restart=always
+RestartSec=10s
+StartLimitInterval=65s
+StartLimitBurst=6
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
系统重启后，mariadb、openldap等依赖组件还未重启完成，go-ldap-admin就会报错，导致启动失败，因此增加重试